### PR TITLE
Add diagonal/distance indicator

### DIFF
--- a/src/scripts/ruler/ruler.js
+++ b/src/scripts/ruler/ruler.js
@@ -58,8 +58,9 @@ export default class Ruler {
 
     this.el.style.width = `${this.rect.width}px`;
     this.el.style.height = `${this.rect.height}px`;
-
-    this.label.innerHTML = `W:${this.rect.width}, H:${this.rect.height}`;
+    
+    var diagonal = Math.sqrt(Math.pow(this.rect.width, 2) + Math.pow(this.rect.height, 2));
+    this.label.innerHTML = `W:${this.rect.width}, H:${this.rect.height}  D:${diagonal.toFixed(1)}`;
 
     console.debug(this.rect.top, this.rect.right, this.rect.bottom, this.rect.left);
   }


### PR DESCRIPTION
Measure diagonal allows easy measurement of objects which are not square or to found out distance between start and current location.